### PR TITLE
module compilation fix and deprecated patch update

### DIFF
--- a/kernel-6.2.patch
+++ b/kernel-6.2.patch
@@ -1,0 +1,126 @@
+--- a/nvidia-drm/nvidia-drm-connector.c
++++ b/nvidia-drm/nvidia-drm-connector.c
+@@ -20,6 +20,8 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
++#include <drm/drm_edid.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+@@ -98,6 +100,7 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
+             break;
+     }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     if (connector->override_edid) {
+         const struct drm_property_blob *edid = connector->edid_blob_ptr;
+ 
+@@ -110,6 +113,25 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
+                     sizeof(pDetectParams->edid.buffer));
+         }
+     }
++#else
++    // Rel. commit "drm/edid: detach debugfs EDID override from EDID property update" (Jani Nikula, 24 Oct 2022)
++    // NOTE: HUGE HACK!
++    mutex_lock(&connector->edid_override_mutex);
++    if (connector->edid_override) {
++        const struct edid *edid = drm_edid_raw(connector->edid_override);
++        size_t edid_length = EDID_LENGTH * (edid->extensions + 1);
++        if (edid_length <= sizeof(pDetectParams->edid.buffer)) {
++            memcpy(pDetectParams->edid.buffer, edid, edid_length);
++            pDetectParams->edid.bufferSize = edid_length;
++            pDetectParams->overrideEdid = NV_TRUE;
++        } else {
++            WARN_ON(edid_length >
++                    sizeof(pDetectParams->edid.buffer));
++        }
++    }
++    mutex_unlock(&connector->edid_override_mutex);
++
++#endif
+ 
+     if (!nvKms->getDynamicDisplayInfo(nv_dev->pDevice, pDetectParams)) {
+         NV_DRM_DEV_LOG_ERR(
+--- a/nvidia-drm/nvidia-drm-drv.c 2023-03-25 13:40:20.697477212 +0200
++++ b/nvidia-drm/nvidia-drm-drv.c	2023-03-25 13:42:49.124894983 +0200
+@@ -20,6 +20,7 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_AVAILABLE and NV_DRM_DRM_GEM_H_PRESENT */
+ 
+ #include "nvidia-drm-priv.h"
+@@ -239,9 +240,12 @@
+     dev->mode_config.preferred_depth = 24;
+     dev->mode_config.prefer_shadow = 1;
+ 
++// Rel. commit "drm: Remove drm_mode_config::fb_base" (Zack Rusin, 18 Oct 2022)
++#if defined(CONFIG_FB) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     /* Currently unused. Update when needed. */
+ 
+     dev->mode_config.fb_base = 0;
++#endif
+ 
+     dev->mode_config.async_page_flip = false;
+ 
+--- a/nvidia/nv-acpi.c	2023-03-25 13:54:22.243143737 +0200
++++ b/nvidia/nv-acpi.c	2023-03-25 14:01:45.016366412 +0200
+@@ -8,6 +8,7 @@
+  * _NVRM_COPYRIGHT_END_
+  */
+ 
++#include <linux/version.h>
+ #define  __NO_VERSION__
+ 
+ #include "nv-misc.h"
+@@ -23,7 +24,10 @@
+ 
+ static int         nv_acpi_add             (struct acpi_device *);
+ 
+-#if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
++static void        nv_acpi_remove_one_arg_void(struct acpi_device *device);
++#elif !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+ static int         nv_acpi_remove_two_args(struct acpi_device *device, int type);
+ #else
+ static int         nv_acpi_remove_one_arg(struct acpi_device *device);
+@@ -73,7 +77,10 @@
+ #endif
+     .ops = {
+         .add = nv_acpi_add,
+-#if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
++        .remove = nv_acpi_remove_one_arg_void,
++#elif !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+         .remove = nv_acpi_remove_two_args,
+ #else
+         .remove = nv_acpi_remove_one_arg,
+@@ -331,7 +338,10 @@
+     return 0;
+ }
+ 
+-#if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
++static void nv_acpi_remove_one_arg_void(struct acpi_device *device)
++#elif !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2
+ static int nv_acpi_remove_two_args(struct acpi_device *device, int type)
+ #else
+ static int nv_acpi_remove_one_arg(struct acpi_device *device)
+@@ -384,8 +394,10 @@
+         module_put(THIS_MODULE);
+         device->driver_data = NULL;
+     }
+-
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0))
+     return status;
++#endif
+ }
+ 
+ static void nv_acpi_event(acpi_handle handle, u32 event_type, void *data)

--- a/nvidia-390xx-kmod.spec
+++ b/nvidia-390xx-kmod.spec
@@ -18,7 +18,7 @@ Name:          nvidia-390xx-kmod
 Epoch:         3
 Version:       390.157
 # Taken over by kmodtool
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       NVIDIA 390xx display driver kernel module
 Group:         System Environment/Kernel
 License:       Redistributable, no modification permitted
@@ -48,6 +48,8 @@ Patch30: use-kbuild-compiler.patch
 Patch31: conftest-verbose.patch
 Patch32: cc_version_check-gcc5.patch
 Patch33: bashisms.patch
+# https://gist.github.com/joanbm/963906fc6772d8955faf1b9cc46c6b04
+Patch34: kernel-6.2.patch
 
 # armhf support
 Patch40: include-swiotlb-header-on-arm.patch
@@ -77,24 +79,25 @@ kmodtool  --target %{_target_cpu}  --repo rpmfusion --kmodname %{name} --filterf
 %setup -T -c
 tar --use-compress-program xz -xf %{_datadir}/%{name}-%{version}/%{name}-%{version}-%{_target_cpu}.tar.xz
 # Apply patches
-%patch12 -p1 -b 12 -d kernel
-%patch13 -p1 -b 13 -d kernel
+%patch -p1 -b 12 -d kernel -P12
+%patch -p1 -b 13 -d kernel -P13
 #patch14 -p1 -b 14 -d kernel
 #patch15 -p1 -b 15 -d kernel
 #patch16 -p1 -b 16 -d kernel
 #patch17 -p1 -b 17 -d kernel
 #patch18 -p1 -b 18 -d kernel
-%patch19 -p1 -b 19
+%patch -p1 -b 19 -P19
 
-%patch30 -p1 -b 30 -d kernel
-%patch31 -p1 -b 31 -d kernel
-%patch32 -p1 -b 32 -d kernel
-%patch33 -p1 -b 33 -d kernel
+%patch -p1 -b 30 -d kernel -P30
+%patch -p1 -b 31 -d kernel -P31
+%patch -p1 -b 32 -d kernel -P32
+%patch -p1 -b 33 -d kernel -P33
+%patch -p1 -b 34 -d kernel -P34
 %ifarch armv7hl
-%patch40 -p1 -b 40 -d kernel
-%patch41 -p1 -b 41 -d kernel
-%patch42 -p1 -b 42 -d kernel
-%patch43 -p1 -b 43 -d kernel
+%patch -p1 -b 40 -d kernel -P40
+%patch -p1 -b 41 -d kernel -P41
+%patch -p1 -b 42 -d kernel -P42
+%patch -p1 -b 43 -d kernel -P43
 %endif
 
 for kernel_version  in %{?kernel_versions} ; do
@@ -122,6 +125,9 @@ done
 
 
 %changelog
+* Sat Mar 25 2023 Ali Erdinc Koroglu <aekoroglu@fedoraproject.org> - 3:390.157-2
+- Patch for kernel 6.2
+
 * Sat Jan 07 2023 Henrik Nordstrom <henrik@henriknordstrom.net> - 3:390.157-1
 - Update to 390.157
 


### PR DESCRIPTION

```
/root/nvidia/tmp/kernel/nvidia/nv-acpi.c:77:19: error: initialization of ‘void (*)(struct acpi_device *)’ from incompatible pointer type ‘int (*)(struct acpi_device *, int)’ [-Werror=incompatible-pointer-types]
   77 |         .remove = nv_acpi_remove_two_args,
```